### PR TITLE
Add Mojang profile fallback for offline mode servers

### DIFF
--- a/src/minecraft/internal/Player.ts
+++ b/src/minecraft/internal/Player.ts
@@ -92,7 +92,18 @@ export class Player {
     const uuid = await this.getUUID();
     const target = Endpoints.get.profile.replace(/({uuid})/g, uuid);
 
-    return getJSON(target);
+    try {
+      return await getJSON(target);
+    } catch (err) {
+      return {
+        'id': uuid,
+        'name': await this.getName(),
+        'properties':  [ {
+          "name" : "textures",
+          "value" : "ewogICJ0aW1lc3RhbXAiIDogMTU5MDg3ODkzNDQ3MCwKICAicHJvZmlsZUlkIiA6ICIzNzljNGIzMTNiNTg0NDcyODZjYjI0NjBiYjM4MzJmNiIsCiAgInByb2ZpbGVOYW1lIiA6ICJqYW1hbG9uIiwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzFhNGFmNzE4NDU1ZDRhYWI1MjhlN2E2MWY4NmZhMjVlNmEzNjlkMTc2OGRjYjEzZjdkZjMxOWE3MTNlYjgxMGIiCiAgICB9CiAgfQp9"
+        } ]
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
Players on offline mode servers have UUIDs that don't match a Mojang
profile, so the Mojang profile API returns empty. This causes the
getJSON() call in getProfile() to return an exception (a 204 error
code). The result is that the chat message doesn't get through to
Matrix, and isn't echoed back to Minecraft players.

Catch errors from getJSON() in getProfile(), and fall back to a default
profile with the player's UUID, display name, and the default steve
head.

To catch the error, we await the result of getJSON() from getProfile().
I'm new to typescript, but my understanding is this shouldn't impact
latency since getProfile() is itself async.

This fixes the main part of Issue #16 but not the generation of a correct avatar from the player's skin.