### PR TITLE
vibeCheck: Report errors similarly to other endpoints

### DIFF
--- a/src/webserver/WebInterface.ts
+++ b/src/webserver/WebInterface.ts
@@ -56,7 +56,7 @@ export class WebInterface {
       // Check if they provided an auth token
       if (!auth) {
         res.status(401);
-        res.send({ "status": "BAD", "error": Errors.noTokenError });
+        res.send(Errors.noTokenError);
         res.end();
         return;
       }
@@ -65,7 +65,7 @@ export class WebInterface {
 
       if (!token) {
         res.status(401);
-        res.send({ "status": "BAD", "error": Errors.noTokenError });
+        res.send(Errors.noTokenError);
         res.end();
         return;
       }
@@ -98,7 +98,7 @@ export class WebInterface {
           `Invalid Bridge`
         );
         res.status(401);
-        res.send({ "status": "BAD", "error": Errors.invalidTokenError });
+        res.send(Errors.invalidTokenError);
         res.end();
       } else {
         LogService.error(
@@ -106,7 +106,7 @@ export class WebInterface {
           err
         );
         res.status(500);
-        res.send({ "status": "BAD", "error": Errors.serverError })
+        res.send(Errors.serverError);
       }
     }
 


### PR DESCRIPTION
Errors are reported from vibeCheck() in a non-standard way, using JSON
status="BAD" and with error containing the error type and message e.g.
from Errors.noTokenError. The other end points have the error type and
message at the top level of the JSON, and thats how the bukkit plugin
expects it too.

Therefore report errors from vibeCheck() in the same way that other
endpoints do so all errors can be handled in the same way by the plugin.